### PR TITLE
Breaks DRY

### DIFF
--- a/Payment.php
+++ b/Payment.php
@@ -22,10 +22,6 @@ use macklus\payments\methods\Transfer;
  */
 class Payment extends Object {
 
-    const PROVIDER_PAYPAL = 'paypal';
-    const PROVIDER_REDSYS = 'redsys';
-    const PROVIDER_TRANSFER = 'transfer';
-
     private $_payment;
     private $_provider;
     public $viewPath;
@@ -67,11 +63,11 @@ class Payment extends Object {
 
     private function _getInstanceOf($provider) {
         switch ($provider) {
-            case self::PROVIDER_PAYPAL:
+            case PaymentModel::PROVIDER_PAYPAL:
                 return new Paypal();
-            case self::PROVIDER_REDSYS;
+            case PaymentModel::PROVIDER_REDSYS;
                 return new Redsys();
-            case self::PROVIDER_TRANSFER:
+            case PaymentModel::PROVIDER_TRANSFER:
                 return new Transfer();
             default:
                 throw new Exception("Unknow provider $provider");


### PR DESCRIPTION
Constants are yet present in PaymentModel, so there is no reason to have it duplicated.